### PR TITLE
Adding change to transfer#valid? test

### DIFF
--- a/spec/transfer_spec.rb
+++ b/spec/transfer_spec.rb
@@ -32,8 +32,9 @@ describe 'Transfer' do
   describe '#valid?' do
     it "can check that both accounts are valid" do
       expect(avi.valid?).to eq (true)
-      expect(amanda.valid?).to eq(true)
-      expect(transfer.valid?).to eq(true)
+      amanda.close_account
+      expect(amanda.valid?).to eq(false)
+      expect(transfer.valid?).to eq(false)
     end
 
     it "calls on the sender and receiver's #valid? methods" do


### PR DESCRIPTION
Changing so the test will fail unless both accounts are valid (several students were passing this test by separately checking first if the sender and then the receiver was valid)